### PR TITLE
Update shebang

### DIFF
--- a/anki-vocab.py
+++ b/anki-vocab.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 import argparse
 import os
 import re


### PR DESCRIPTION
The previous shebang did not work on my computer running macOS 13.1.

Updating to use a more portable shebang that is officially recommended¹.

¹ https://docs.python.org/3/using/unix.html?highlight=shebang#miscellaneous